### PR TITLE
readme: add to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ homepage = "https://github.com/brayniac/mpmc"
 documentation = "https://docs.rs/mpmc"
 repository = "https://github.com/brayniac/mpmc"
 
+readme = "README.md"
 license-file = "LICENSE"
 
 description = "copy-pasted from old rust stdlib"


### PR DESCRIPTION
- add the README to Cargo.toml for display on crates.io