### PR TITLE
update CI badge in readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: rust
-rust:
-- stable
-- beta
-- nightly
-os:
-- linux
-- osx

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ mpmc is a multi-produce multi-consumer queue which has been copied from the old 
 [![conduct-badge][]][conduct] [![ci-badge][]][ci] [![downloads-badge][] ![release-badge][]][crate] [![license-badge][]](#license)
 
 [conduct-badge]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
-[ci-badge]: https://github.com/brayniac/mpmc/actions/workflows/cargo.yml/badge.svg
+[ci-badge]: https://github.com/brayniac/mpmc/actions/workflows/cargo.yml/badge.svg?branch=master
 [downloads-badge]: https://img.shields.io/crates/d/mpmc.svg
 [release-badge]: https://img.shields.io/crates/v/mpmc.svg
 [license-badge]: https://img.shields.io/crates/l/mpmc.svg
 [conduct]: https://brayniac.github.io/conduct
-[ci]: https://github.com/brayniac/mpmc/actions/workflows/cargo.yml
+[ci]: https://github.com/brayniac/mpmc/actions/workflows/cargo.yml?query=branch%3Amaster
 [crate]: https://crates.io/crates/mpmc
 [Cargo]: https://github.com/rust-lang/cargo
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ mpmc is a multi-produce multi-consumer queue which has been copied from the old 
 [release-badge]: https://img.shields.io/crates/v/mpmc.svg
 [license-badge]: https://img.shields.io/crates/l/mpmc.svg
 [conduct]: https://brayniac.github.io/conduct
-[travis]: https://travis-ci.org/brayniac/mpmc
+[ci]: https://github.com/brayniac/mpmc/actions/workflows/cargo.yml
 [crate]: https://crates.io/crates/mpmc
 [Cargo]: https://github.com/rust-lang/cargo
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 mpmc is a multi-produce multi-consumer queue which has been copied from the old Rust stdlib
 
-[![conduct-badge][]][conduct] [![travis-badge][]][travis] [![downloads-badge][] ![release-badge][]][crate] [![license-badge][]](#license)
+[![conduct-badge][]][conduct] [![ci-badge][]][ci] [![downloads-badge][] ![release-badge][]][crate] [![license-badge][]](#license)
 
 [conduct-badge]: https://img.shields.io/badge/%E2%9D%A4-code%20of%20conduct-blue.svg
-[travis-badge]: https://img.shields.io/travis/brayniac/mpmc/master.svg
+[ci-badge]: https://github.com/brayniac/mpmc/actions/workflows/cargo.yml/badge.svg
 [downloads-badge]: https://img.shields.io/crates/d/mpmc.svg
 [release-badge]: https://img.shields.io/crates/v/mpmc.svg
 [license-badge]: https://img.shields.io/crates/l/mpmc.svg


### PR DESCRIPTION
Updates the CI badge in the readme and removes old travis config.
